### PR TITLE
updated trove classifier in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'Development Status :: 3 - Alpha',
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
         'Natural Language :: English',
+        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: Implementation :: CPython',
         'Operating System :: POSIX',


### PR DESCRIPTION
Updated trove classifier in setup.py to indicate that the library requires Python 3.4

codetransformer/core.py has a dependency on `dis.Bytecode` which was not added until Python 3.4. Example stacktrace on python 3.3.5:

```
Traceback (most recent call last):
  File "bar.py", line 1, in <module>
    import codetransformer
  File "/Users/username/anaconda/envs/py3k/lib/python3.3/site-packages/codetransformer/__init__.py", line 1, in <module>
    from .core import CodeTransformer, Instruction, ops
  File "/Users/username/anaconda/envs/py3k/lib/python3.3/site-packages/codetransformer/core.py", line 3, in <module>
    from dis import Bytecode, opname, opmap, hasjabs, hasjrel, HAVE_ARGUMENT
ImportError: cannot import name Bytecode
```
