### PR TITLE
Fix typo in transformers/literals.py

### DIFF
--- a/codetransformer/transformers/literals.py
+++ b/codetransformer/transformers/literals.py
@@ -181,7 +181,7 @@ def overloaded_constants(type_):
         A new code transformer class that will overload the provided
         literal types.
     """
-    typename = type.__name__
+    typename = type_.__name__
     if not typename.endswith('s'):
         typename += 's'
 


### PR DESCRIPTION
A simple typo actually made the name of overloaded constants wrong (it would always be `abc.overloaded_types` no matter what). This fixes it.
