### PR TITLE
Add support for CPython 3.5+

### DIFF
--- a/codetransformer/transformers/literals.py
+++ b/codetransformer/transformers/literals.py
@@ -99,34 +99,41 @@ class overloaded_dicts(CodeTransformer):
 
         yield instr
 
-    @pattern(instructions.STORE_MAP)
-    def _store_map(self, instr):
-        # TOS  = k
-        # TOS1 = v
-        # TOS2 = m
-        # TOS3 = m
+    try:
 
-        yield instructions.ROT_THREE().steal(instr)
-        # TOS  = v
-        # TOS1 = m
-        # TOS2 = k
-        # TOS3 = m
+        @pattern(instructions.STORE_MAP)
+        def _store_map(self, instr):
+            # TOS  = k
+            # TOS1 = v
+            # TOS2 = m
+            # TOS3 = m
 
-        yield instructions.ROT_THREE()
-        # TOS  = m
-        # TOS1 = k
-        # TOS2 = v
-        # TOS3 = m
+            yield instructions.ROT_THREE().steal(instr)
+            # TOS  = v
+            # TOS1 = m
+            # TOS2 = k
+            # TOS3 = m
 
-        yield instructions.ROT_TWO()
-        # TOS  = k
-        # TOS1 = m
-        # TOS2 = v
-        # TOS3 = m
+            yield instructions.ROT_THREE()
+            # TOS  = m
+            # TOS1 = k
+            # TOS2 = v
+            # TOS3 = m
 
-        yield instructions.STORE_SUBSCR()
-        # TOS  = m
+            yield instructions.ROT_TWO()
+            # TOS  = k
+            # TOS1 = m
+            # TOS2 = v
+            # TOS3 = m
 
+            yield instructions.STORE_SUBSCR()
+            # TOS  = m
+
+    except AttributeError:
+
+        def _store_map(self, instr):
+            raise NotImplementedError("The 'STORE_MAP' opcode is "
+                                      "not supported in CPython 3.5+")
 
 ordereddict_literals = overloaded_dicts(OrderedDict)
 


### PR DESCRIPTION
The package fails on import with a `AttributeError: module 'codetransformer.instructions' has no attribute 'STORE_MAP'`. After some debugging, digging and research, I found out that this specific opcode was removed in CPython 3.5. I am proposing a (hopefully temporary) fix to this. This allows the package to not fail on import, but the code might fail in other places. If there's a better way to fix this, I'll be glad to do so.

I really love this package. Expect to see a lot of contributions from me in the coming days/weeks.
