### PR TITLE
ENH: make subclasses of codetransforers inherit the parent's patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ benchmarks.db
 
 # pypi
 MANIFEST
+
+# pytest
+.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ before_script:
 
 script:
  - py.test codetransformer
+
+notifications:
+  email: false

--- a/codetransformer/core.py
+++ b/codetransformer/core.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from contextlib import contextmanager
 from ctypes import py_object, pythonapi
+from itertools import chain
 from operator import attrgetter
 from types import CodeType, FunctionType
 
@@ -39,9 +40,14 @@ class CodeTransformerMeta(type):
     ``codetransformer.pattern.pattern``
     """
     def __new__(mcls, name, bases, dict_):
-        dict_['_patterndispatcher'] = patterndispatcher(
-            *(v for v in dict_.values() if isinstance(v, boundpattern))
-        )
+        dict_['_patterndispatcher'] = patterndispatcher(*chain(
+            (v for v in dict_.values() if isinstance(v, boundpattern)),
+            *(
+                d and d.patterns for d in (
+                    getattr(b, '_patterndispatcher', ()) for b in bases
+                )
+            )
+        ))
         return super().__new__(mcls, name, bases, dict_)
 
     def __prepare__(self, bases):

--- a/codetransformer/patterns.py
+++ b/codetransformer/patterns.py
@@ -257,6 +257,9 @@ class boundpattern(immutable):
     __slots__ = '_compiled', '_startcodes', '_f'
 
     def __get__(self, instance, owner):
+        if instance is None:
+            return self
+
         return type(self)(
             self._compiled,
             self._startcodes,
@@ -282,18 +285,21 @@ class NoMatches(Exception):
 
 
 class patterndispatcher(immutable):
-    """A set of boundpatterns that can dispatch onto instrs.
+    """A set of patterns that can dispatch onto instrs.
     """
-    __slots__ = '*_boundpatterns',
+    __slots__ = '*patterns',
 
     def __get__(self, instance, owner):
+        if instance is None:
+            return self
+
         return type(self)(*map(
             methodcaller('__get__', instance, owner),
-            self._boundpatterns,
+            self.patterns,
         ))
 
     def __call__(self, compiled_instrs, instrs, startcode):
-        for p in self._boundpatterns:
+        for p in self.patterns:
             try:
                 return p(compiled_instrs, instrs, startcode)
             except KeyError:

--- a/codetransformer/tests/test_core.py
+++ b/codetransformer/tests/test_core.py
@@ -1,0 +1,51 @@
+from codetransformer import CodeTransformer, pattern
+
+
+def test_inherit_patterns():
+    class C(CodeTransformer):
+        matched = False
+
+        @pattern(...)
+        def _(self, instr):
+            self.matched = True
+            yield instr
+
+    class D(C):
+        pass
+
+    d = D()
+    assert not d.matched
+
+    @d
+    def f():
+        pass
+
+    assert d.matched
+
+
+def test_override_patterns():
+    class C(CodeTransformer):
+        matched_super = False
+        matched_sub = False
+
+        @pattern(...)
+        def _(self, instr):
+            self.matched_super = True
+            yield instr
+
+    class D(C):
+        @pattern(...)
+        def _(self, instr):
+            self.matched_sub = True
+            yield instr
+
+    d = D()
+    assert not d.matched_super
+    assert not d.matched_sub
+
+    @d
+    def f():
+        pass
+
+    assert d.matched_sub
+    assert not d.matched_super

--- a/codetransformer/transformers/literals.py
+++ b/codetransformer/transformers/literals.py
@@ -62,7 +62,7 @@ class overloaded_dicts(CodeTransformer):
         yield instructions.STORE_FAST('__map__')
 
         *body, map_add = instrs
-        yield from body
+        yield from self.patterndispatcher(body)
         # TOS  = k
         # TOS1 = v
 
@@ -237,8 +237,8 @@ decimal_literals = overloaded_floats(Decimal)
 
 
 def _start_comprehension(self, *instrs):
-    yield from instrs
     self.begin(IN_COMPREHENSION)
+    yield from self.patterndispatcher(instrs)
 
 
 def _return_value(self, instr):


### PR DESCRIPTION
The use case here is that `lazy_function` wanted to pull a bunch of patterns in through mixins; however, I couldn't because these were not inherited.
