### PR TITLE
ENH: Add support for decompiling if-statements.

### DIFF
--- a/codetransformer/decompiler.py
+++ b/codetransformer/decompiler.py
@@ -89,6 +89,7 @@ def _instr(instr, queue, stack, body, context):
     )
 
 
+@_process_instr.register(instrs.POP_JUMP_IF_TRUE)
 @_process_instr.register(instrs.POP_JUMP_IF_FALSE)
 def _process_jump(instr, queue, stack, body, context):
     stack_effect_until_target = sum(
@@ -111,6 +112,9 @@ def make_if_statement(instr, queue, stack, context):
     Make an ast.If block from a POP_JUMP_IF_TRUE or POP_JUMP_IF_FALSE.
     """
     test_expr = make_expr(stack)
+    if isinstance(instr, instrs.POP_JUMP_IF_TRUE):
+        test_expr = ast.UnaryOp(op=ast.Not(), operand=test_expr)
+
     first_block = popwhile(op.is_not(instr.arg), queue, side='left')
     jump_to_end = expect(
         first_block.pop(), instrs.JUMP_FORWARD, "at end of if-block"

--- a/codetransformer/decompiler.py
+++ b/codetransformer/decompiler.py
@@ -1,6 +1,7 @@
 import ast
 from collections import deque
 from functools import singledispatch
+from itertools import takewhile
 import types
 
 from toolz import complement, compose, curry
@@ -86,6 +87,48 @@ def _instr(instr, queue, stack, body, context):
     raise DecompilationError(
         "Don't know how to decompile instructions of type %s" % type(instr)
     )
+
+
+@_process_instr.register(instrs.POP_JUMP_IF_FALSE)
+def _process_jump(instr, queue, stack, body, context):
+    stack_effect_until_target = sum(
+        map(
+            op.attrgetter('stack_effect'),
+            takewhile(op.is_not(instr.arg), queue)
+        )
+    )
+    if stack_effect_until_target == 0:
+        body.append(make_if_statement(instr, queue, stack, context))
+        return
+    else:
+        raise DecompilationError(
+            "Don't know how to decompile `and`/`or`/`ternary` exprs."
+        )
+
+
+def make_if_statement(instr, queue, stack, context):
+    """
+    Make an ast.If block from a POP_JUMP_IF_TRUE or POP_JUMP_IF_FALSE.
+    """
+    test_expr = make_expr(stack)
+    first_block = popwhile(op.is_not(instr.arg), queue, side='left')
+    jump_to_end = expect(
+        first_block.pop(), instrs.JUMP_FORWARD, "at end of if-block"
+    )
+
+    body = instrs_to_body(first_block, context)
+
+    # First instruction after the whole if-block.
+    end = jump_to_end.arg
+    if instr.arg is jump_to_end.arg:
+        orelse = []
+    else:
+        orelse = instrs_to_body(
+            popwhile(op.is_not(end), queue, side='left'),
+            context,
+        )
+
+    return ast.If(test=test_expr, body=body, orelse=orelse)
 
 
 @_process_instr.register(instrs.EXTENDED_ARG)

--- a/codetransformer/tests/test_decompiler.py
+++ b/codetransformer/tests/test_decompiler.py
@@ -725,3 +725,65 @@ def test_nested_with():
             """
         ),
     )
+
+
+def test_simple_if():
+    check(
+        dedent(
+            """
+            if a:
+                b = c
+            x = "end"
+            """
+        )
+    )
+
+
+def test_if_else():
+    check(
+        dedent(
+            """
+            if a:
+                b = c
+            else:
+                b = d
+            x = "end"
+            """
+        )
+    )
+
+
+def test_if_elif():
+    check(
+        dedent(
+            """\
+            if a:
+                b = c
+            elif d:
+                e = f
+            elif g:
+                h = i
+            else:
+                j = k
+            x = "end"
+            """
+        )
+    )
+    check(
+        dedent(
+            """
+            if a:
+                x = "before_b"
+                if b:
+                    x = "in_b"
+                else:
+                    x = "else_b"
+                w = "after_b"
+            elif c:
+                x = "in_c"
+            else:
+                x = "in_else"
+            x = "end"
+            """
+        )
+    )

--- a/codetransformer/tests/test_decompiler.py
+++ b/codetransformer/tests/test_decompiler.py
@@ -753,29 +753,39 @@ def test_if_else():
     )
 
 
-def test_if_elif():
+@pytest.mark.parametrize(
+    'last_statement,prefix',
+    product(
+        ("", "x = 'end'"),
+        ("not", "not not"),
+    ),
+)
+def test_if_elif(last_statement, prefix):
     check(
         dedent(
             """\
-            if a:
+            if {prefix} a:
                 b = c
             elif d:
                 e = f
-            elif g:
+            elif {prefix} g:
                 h = i
             else:
                 j = k
-            x = "end"
+            {last_statement}
             """
-        )
+        ).format(prefix=prefix, last_statement=last_statement)
     )
+
     check(
         dedent(
             """
             if a:
                 x = "before_b"
-                if b:
+                if {prefix} b:
                     x = "in_b"
+                elif b:
+                    x = "in_elif_b"
                 else:
                     x = "else_b"
                 w = "after_b"
@@ -783,7 +793,7 @@ def test_if_elif():
                 x = "in_c"
             else:
                 x = "in_else"
-            x = "end"
+            {last_statement}
             """
-        )
+        ).format(prefix=prefix, last_statement=last_statement)
     )


### PR DESCRIPTION
This is mostly interesting because it's tricky to tell the difference between an `if` statement and a short-circuiting operator or a ternary.  The key to figuring out that we're in an if statement is looking at the cumulative stack effect between a jump and its target.  It's zero only when we're in a jump generated by an `if`.
