### PR TITLE
ENH: compare op enum and instr equality

### DIFF
--- a/codetransformer/instructions.py
+++ b/codetransformer/instructions.py
@@ -233,7 +233,7 @@ class Instruction(InstructionMeta._marker, metaclass=InstructionMeta):
 
         Notes
         -----
-        This is a seperate concept from instruction identity. Two seperate
+        This is a separate concept from instruction identity. Two seperate
         instructions can be equivalent without being the same exact instance.
         This means that two equivalent instructions can be at different points
         in the bytecode or be targeted by different jumps.


### PR DESCRIPTION
This cleans up some rough edges I saw in Jim's codetransformer.
- Makes `COMPARE_OP` use enums for the input. There are also class level constructors for the different types like: `COMPARE_OP.LT`
  note: `COMPARE_OP.LT is not COMPARE_OP.LT`. This means we can use these for equality or take ownership and start jumping to them and so on. The integer enum is `COMPARE_OP.comparators`.
- Makes the jump instruction constructor manage the `_target_of` set of the argument.
- Adds a way for subclasses to type check and normalize their inputs.
