### PR TITLE
BUG: fix issue which dropped the vararg and varkeyword info in transforms

### DIFF
--- a/codetransformer/core.py
+++ b/codetransformer/core.py
@@ -193,7 +193,7 @@ class CodeTransformer(metaclass=CodeTransformerMeta):
 
             return Code(
                 post_transform,
-                code.argnames,
+                code.param_signature,
                 cellvars=self.transform_cellvars(code.cellvars),
                 freevars=self.transform_freevars(code.freevars),
                 name=name if name is not None else code.name,

--- a/codetransformer/tests/test_core.py
+++ b/codetransformer/tests/test_core.py
@@ -128,3 +128,49 @@ def test_no_context():
         c.context
 
     assert str(e.value) == 'no active transformation context'
+
+
+def test_nop():
+    result = object()
+
+    @CodeTransformer()
+    def f():
+        return result
+
+    assert f() is result
+
+    @CodeTransformer()
+    def f(a):
+        return a
+
+    assert f(result) is result
+
+    @CodeTransformer()
+    def f(a=result):
+        return a
+
+    assert f() is result
+
+    @CodeTransformer()
+    def f(*args):
+        return args[0]
+
+    assert f(result) is result
+
+    @CodeTransformer()
+    def f(*args, a):
+        return a
+
+    assert f(a=result) is result
+
+    @CodeTransformer()
+    def f(**kwargs):
+        return kwargs['a']
+
+    assert f(a=result) is result
+
+    @CodeTransformer()
+    def f(a, *b, c, **d):
+        return a, b, c, d
+
+    assert f(1, 2, c=3, d=4) == (1, (2,), 3, {'d': 4})


### PR DESCRIPTION
fixes https://github.com/llllllllll/codetransformer/issues/67

This also found an issue where a function with lone-star syntax was treated as having varargs but that flag is not set when lone star syntax is used.