### PR TITLE
BUG: fix `d` and `%dis` in 3.7

### DIFF
--- a/codetransformer/utils/pretty.py
+++ b/codetransformer/utils/pretty.py
@@ -214,10 +214,15 @@ def d(obj, mode='exec', file=None):
     if file is None:
         file = sys.stdout
 
+    if sys.version_info >= (3, 7):
+        dis_f = partial(dis.dis, depth=0)
+    else:
+        dis_f = dis.dis
+
     for name, co in walk_code(extract_code(obj, compile_mode=mode)):
         print(name, file=file)
         print('-' * len(name), file=file)
-        dis.dis(co, file=file)
+        dis_f(co, file=file)
         print('', file=file)
 
 


### PR DESCRIPTION
As of Python 3.7, dis.dis has a similar recursive printing feature as `d`. This
causes us to print two copies of each code object in the tree.

This patch passes `depth=0` to dis.dis for Python >= 3.7. I didn't just switch
to `dis.dis` because I think it produces worse labels, for example:

dis.dis:
```
In [3]: %dis [x for x in y]
  1           0 LOAD_CONST               0 (<code object <listcomp> at 0x7f2f262aa300, file "<dis>", line 1>)
              2 LOAD_CONST               1 ('<listcomp>')
              4 MAKE_FUNCTION            0
              6 LOAD_NAME                0 (y)
              8 GET_ITER
             10 CALL_FUNCTION            1
             12 RETURN_VALUE

Disassembly of <code object <listcomp> at 0x7f2f262aa300, file "<dis>", line 1>:
  1           0 BUILD_LIST               0
              2 LOAD_FAST                0 (.0)
        >>    4 FOR_ITER                 8 (to 14)
              6 STORE_FAST               1 (x)
              8 LOAD_FAST                1 (x)
             10 LIST_APPEND              2
             12 JUMP_ABSOLUTE            4
        >>   14 RETURN_VALUE
```

`d`:
```
In [2]: %dis [x for x in y]
<module>
--------
  1           0 LOAD_CONST               0 (<code object <listcomp> at 0x7f408047d270, file "<show>", line 1>)
              2 LOAD_CONST               1 ('<listcomp>')
              4 MAKE_FUNCTION            0
              6 LOAD_NAME                0 (y)
              8 GET_ITER
             10 CALL_FUNCTION            1
             12 POP_TOP
             14 LOAD_CONST               2 (None)
             16 RETURN_VALUE

<module>.<listcomp>
-------------------
  1           0 BUILD_LIST               0
              2 LOAD_FAST                0 (.0)
        >>    4 FOR_ITER                 8 (to 14)
              6 STORE_FAST               1 (x)
              8 LOAD_FAST                1 (x)
             10 LIST_APPEND              2
             12 JUMP_ABSOLUTE            4
        >>   14 RETURN_VALUE
```