### PR TITLE
ENH: Patch for python 3.8

### DIFF
--- a/codetransformer/code.py
+++ b/codetransformer/code.py
@@ -218,6 +218,7 @@ def _freevar_argname(arg, cellvars, freevars):
 
 
 def pycode(argcount,
+           posonlyargcount,
            kwonlyargcount,
            nlocals,
            stacksize,
@@ -238,23 +239,43 @@ def pycode(argcount,
     --------
     types.CodeType
     """
-    return CodeType(
-        argcount,
-        kwonlyargcount,
-        nlocals,
-        stacksize,
-        flags,
-        codestring,
-        constants,
-        names,
-        varnames,
-        filename,
-        name,
-        firstlineno,
-        lnotab,
-        freevars,
-        cellvars,
-    )
+    if hasattr(CodeType, "co_posonlyargcount"):
+        return CodeType(
+            argcount,
+            posonlyargcount,  # new in 3.8
+            kwonlyargcount,
+            nlocals,
+            stacksize,
+            flags,
+            codestring,
+            constants,
+            names,
+            varnames,
+            filename,
+            name,
+            firstlineno,
+            lnotab,
+            freevars,
+            cellvars,
+        )
+    else:
+        return CodeType(
+            argcount,
+            kwonlyargcount,
+            nlocals,
+            stacksize,
+            flags,
+            codestring,
+            constants,
+            names,
+            varnames,
+            filename,
+            name,
+            firstlineno,
+            lnotab,
+            freevars,
+            cellvars,
+        )
 
 
 class Code:
@@ -581,22 +602,23 @@ class Code:
                 # with wordcode, all instructions are padded to 2 bytes
                 bc.append(0)
 
-        return CodeType(
-            self.argcount,
-            self.kwonlyargcount,
-            len(varnames),
-            self.stacksize,
-            self.py_flags,
-            bytes(bc),
-            consts,
-            names,
-            varnames,
-            self.filename,
-            self.name,
-            self.firstlineno,
-            self.py_lnotab,
-            freevars,
-            cellvars,
+        return pycode(
+            argcount=self.argcount,
+            posonlyargcount=0,
+            kwonlyargcount=self.kwonlyargcount,
+            nlocals=len(varnames),
+            stacksize=self.stacksize,
+            flags=self.py_flags,
+            codestring=bytes(bc),
+            constants=consts,
+            names=names,
+            varnames=varnames,
+            filename=self.filename,
+            name=self.name,
+            firstlineno=self.firstlineno,
+            lnotab=self.py_lnotab,
+            freevars=freevars,
+            cellvars=cellvars
         )
 
     @property

--- a/codetransformer/tests/test_code.py
+++ b/codetransformer/tests/test_code.py
@@ -154,6 +154,7 @@ def test_code_flags(sample_flags):
 
         code = Code.from_pycode(pycode(
             argcount=0,
+            posonlyargcount=0,
             kwonlyargcount=0,
             nlocals=2,
             stacksize=0,


### PR DESCRIPTION
Patch for 3.8. Doesn't actually add support for `posonlyargcount`, just makes it so code doesn't crash. 

Closes https://github.com/llllllllll/codetransformer/issues/72

There's still some test failures on 3.8 that are a bit confusing, but I believe the functionality itself works. 

@llllllllll - I'm not sure if this fix is what you were describing in https://github.com/llllllllll/codetransformer/issues/72#issuecomment-584981635