### PR TITLE
[FIX] typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ MANIFEST
 .cache
 
 htmlcov
+
+# intellij
+.idea/

--- a/codetransformer/code.py
+++ b/codetransformer/code.py
@@ -307,6 +307,7 @@ class Code:
         '_instrs',
         '_argnames',
         '_argcount',
+        '_posonlyargcount',
         '_kwonlyargcount',
         '_cellvars',
         '_freevars',
@@ -334,6 +335,7 @@ class Code:
 
         # The starting varnames (the names of the arguments to the function)
         argcount = [0]
+        posonlyargcount = [0]
         kwonlyargcount = [0]
         argcounter = argcount  # Which set of args are we currently counting.
         _argnames = []
@@ -377,6 +379,7 @@ class Code:
         self._instrs = instrs
         self._argnames = tuple(_argnames)
         self._argcount = argcount[0]
+        self._posonlyargcount = posonlyargcount[0]
         self._kwonlyargcount = kwonlyargcount[0]
         self._cellvars = cellvars
         self._freevars = freevars
@@ -583,6 +586,7 @@ class Code:
 
         return CodeType(
             self.argcount,
+            self.posonlyargcount,
             self.kwonlyargcount,
             len(varnames),
             self.stacksize,
@@ -598,6 +602,28 @@ class Code:
             freevars,
             cellvars,
         )
+    # to be correct in python 3.10
+    # elif sys.version_info >= (3, 10):
+    #     def __new__(
+    #         cls,
+    #         __argcount: int, ok
+    #         __posonlyargcount: int, NOK
+    #         __kwonlyargcount: int, ok
+    #         __nlocals: int, ok
+    #         __stacksize: int, ok
+    #         __flags: int, ok
+    #         __codestring: bytes, OK?
+    #         __constants: tuple[object, ...], ok
+    #         __names: tuple[str, ...], ok
+    #         __varnames: tuple[str, ...], ok
+    #         __filename: str, ok
+    #         __name: str, ok
+    #         __firstlineno: int, ok
+    #         __linetable: bytes, ok
+    #         __freevars: tuple[str, ...] = ..., ok
+    #         __cellvars: tuple[str, ...] = ..., ok
+    #     ) -> Self: ...
+
 
     @property
     def instrs(self):
@@ -621,6 +647,12 @@ class Code:
         This does not include varargs (\*args).
         """
         return self._argcount
+
+    @property
+    def posonlyargcount(self):
+        """The number of arguments this code object accepts.
+        """
+        return self._posonlyargcount
 
     @property
     def kwonlyargcount(self):

--- a/codetransformer/transformers/constants.py
+++ b/codetransformer/transformers/constants.py
@@ -117,7 +117,7 @@ class asconstants(CodeTransformer):
             )
         return super().transform(code, **kwargs)
 
-    @pattern(LOAD_NAME | LOAD_GLOBAL | LOAD_DEREF | LOAD_CLASSDEREF)
+    @pattern(LOAD_NAME or LOAD_GLOBAL or LOAD_DEREF or LOAD_CLASSDEREF)
     def _load_name(self, instr):
         name = instr.arg
         if name not in self._constnames:
@@ -127,8 +127,8 @@ class asconstants(CodeTransformer):
         yield LOAD_CONST(self._constnames[name]).steal(instr)
 
     _store = pattern(
-        STORE_NAME | STORE_GLOBAL | STORE_DEREF | STORE_FAST,
+        STORE_NAME or STORE_GLOBAL or STORE_DEREF or STORE_FAST,
     )(_assign_or_del('assign to'))
     _delete = pattern(
-        DELETE_NAME | DELETE_GLOBAL | DELETE_DEREF | DELETE_FAST,
+        DELETE_NAME or DELETE_GLOBAL or DELETE_DEREF or DELETE_FAST,
     )(_assign_or_del('delete'))

--- a/codetransformer/transformers/pattern_matched_exceptions.py
+++ b/codetransformer/transformers/pattern_matched_exceptions.py
@@ -85,7 +85,7 @@ class pattern_matched_exceptions(CodeTransformer):
             yield CALL_FUNCTION_VAR(1)
 
         del CALL_FUNCTION_VAR
-    else:
+    elif sys.version_info < (3, 9):
         from ..instructions import (
             CALL_FUNCTION_EX,
             BUILD_TUPLE_UNPACK_WITH_CALL,

--- a/docs/source/code-objects.rst
+++ b/docs/source/code-objects.rst
@@ -28,12 +28,12 @@ object and inspect its contents::
     >>> def add2(x):
     ...     return x + 2
     ...
-    >>> co = Code.from_pycode(add.__code__)
+    >>> co = Code.from_pycode(add2.__code__)
     >>> co.instrs
     (LOAD_FAST('x'), LOAD_CONST(2), BINARY_ADD, RETURN_VALUE)
     >>> co.argnames
     ('x',)
-    >>> c.consts
+    >>> co.consts
     (2,)
 
 We can convert our Code object back into its raw form via the

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,16 @@
 [tox]
-envlist=py{34,35,36}
-skip_missing_interpreters=True
+envlist = py{34,35,36,310}
+skip_missing_interpreters = True
 
 [testenv]
-commands=
+deps =
+    pytest
+    pytest-cov
+commands =
     pip install -e .[dev]
-    py.test
+    pytest --cov=codetransformer --cov-report=term-missing
 
 [pytest]
-addopts = --doctest-modules --cov codetransformer --cov-report term-missing --ignore setup.py
+addopts = --doctest-modules
 testpaths = codetransformer
 norecursedirs = decompiler


### PR DESCRIPTION
```py
>>> co = Code.from_pycode(add.__code__)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'add' is not defined
```
```py
>>> co = Code.from_pycode(add2.__code__)
>>> 
```